### PR TITLE
support for resource names as string for fragment attribute

### DIFF
--- a/MvvmCross/Droid/Droid/Views/Attributes/MvxFragmentAttribute.cs
+++ b/MvvmCross/Droid/Droid/Views/Attributes/MvxFragmentAttribute.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using Android.Views;
 using MvvmCross.Core.Views;
+using MvvmCross.Platform;
+using MvvmCross.Platform.Droid;
 
 namespace MvvmCross.Droid.Views.Attributes
 {
@@ -32,6 +34,31 @@ namespace MvvmCross.Droid.Views.Attributes
             PopEnterAnimation = popEnterAnimation;
             PopExitAnimation = popExitAnimation;
             TransitionStyle = transitionStyle;
+            IsCacheableFragment = isCacheableFragment;
+        }
+
+        public MvxFragmentAttribute(
+            Type activityHostViewModelType, 
+            string fragmentContentResourceName, 
+            bool addToBackStack = false,
+            string enterAnimation = null,
+            string exitAnimation = null,
+            string popEnterAnimation = null,
+            string popExitAnimation = null,
+            string transitionStyle = null,
+            bool isCacheableFragment = true
+        )
+        {
+            var context = Mvx.Resolve<IMvxAndroidGlobals>().ApplicationContext;
+
+            ActivityHostViewModelType = activityHostViewModelType;
+            FragmentContentId = fragmentContentResourceName!=null ? context.Resources.GetIdentifier(fragmentContentResourceName, "id", context.PackageName) : Android.Resource.Id.Content;
+            AddToBackStack = addToBackStack;
+            EnterAnimation = enterAnimation!=null ? context.Resources.GetIdentifier(enterAnimation, "animation", context.PackageName) : int.MinValue;
+            ExitAnimation = exitAnimation!= null ? context.Resources.GetIdentifier(exitAnimation, "animation", context.PackageName) : int.MinValue;
+            PopEnterAnimation = popEnterAnimation!= null ? context.Resources.GetIdentifier(popEnterAnimation, "animation", context.PackageName) : int.MinValue;
+            PopExitAnimation = popExitAnimation!= null ? context.Resources.GetIdentifier(popExitAnimation, "animation", context.PackageName) : int.MinValue;
+            TransitionStyle = transitionStyle!= null ? context.Resources.GetIdentifier(transitionStyle, "style", context.PackageName) : int.MinValue;
             IsCacheableFragment = isCacheableFragment;
         }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It is a feature

### :arrow_heading_down: What is the current behavior?
Now it is impossible to use MvxFragmentAttribure in Android library class. In Android projects Resource ids are constant but in Android Library they are static therefore it is impossible to use it in Attributes.

### :new: What is the new behavior (if this is a feature change)?
This PR introduces additional Attribute constructor with string which is converted to int.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs
#2097

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/MvvmCross/MvvmCross#code-style-guidelines))
- [ ] Relevant documentation was updated ([docs style guide](https://www.mvvmcross.com/documentation/contribute/mvvmcross-docs-style-guide))
- [ ] Nuspec files were updated (when applicable)
- [ ] Rebased onto current develop
